### PR TITLE
refactor(graphql): improve JSON schema conversion

### DIFF
--- a/mcp_graphql/types.py
+++ b/mcp_graphql/types.py
@@ -36,7 +36,7 @@ class JsonSchema(TypedDict, total=False):
     properties: dict[str, "JsonSchema"]
     required: bool | list[str]
     items: "JsonSchema"
-    oneOf: list[dict[str, str]] | None
+    enum: list[str]
 
 
 # Create simpler flattened definition for nested selections to avoid complex recursive types

--- a/nix/pkgs/deploy/default.nix
+++ b/nix/pkgs/deploy/default.nix
@@ -9,9 +9,14 @@ pkgs.writeShellApplication {
   text = ''
     pyproject_toml="pyproject.toml"
 
-    if ! git diff HEAD~1 HEAD -- "''${pyproject_toml}" | grep -q '^[-+]version'; then
-      echo "''${pyproject_toml} version has not changed. Skipping deployment." \
-        && return 0
+    # Determine previous revision if it exists (repository may have fewer than two commits)
+    prev_rev=$(git rev-parse --quiet --verify HEAD~1)
+
+    if [[ -n "''${prev_rev}" ]]; then
+      if ! git diff "''${prev_rev}" HEAD -- "''${pyproject_toml}" | grep -q '^[-+]version'; then
+        echo "''${pyproject_toml} version has not changed. Skipping deployment."
+        exit 0
+      fi
     fi
 
     set -o allexport

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-graphql"
-version = "0.3.2"
+version = "0.3.3"
 description = "MCP server for GraphQL"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ cli = [
 
 [[package]]
 name = "mcp-graphql"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- Enhanced the `convert_type_to_json_schema` function to ensure proper handling of `GraphQLNonNull`, `GraphQLInputObjectType`, and `GraphQLInputField`.
- Updated logging to provide detailed information about inner schemas and argument schemas during conversion.
- Increased the maximum depth for schema conversion to improve handling of complex types.
- Adjusted the `JsonSchema` type definition to replace `oneOf` with `enum` for better clarity.