### PR TITLE
feat(back): add support for predefined GraphQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ python -m mcp_graphql --api-url="https://api.example.com/graphql" --auth-token="
 ### Available options
 
 - `--api-url`: GraphQL API URL (required)
-- `--auth-token`: Authentication token (optional)
+- `--auth-token`: Authentication token (optional, can also be set via `MCP_AUTH_TOKEN` environment variable)
 - `--auth-type`: Authentication type, default is "Bearer" (optional)
 - `--auth-headers`: Custom authentication headers in JSON format (optional)
 
@@ -168,6 +168,16 @@ uv sync
 ```bash
 ruff check .
 ```
+
+### Running the server in development mode
+
+When working locally you can start the MCP GraphQL server with hot-reloading and inspect its tools using the Model Context Protocol Inspector:
+
+```bash
+npx "@modelcontextprotocol/inspector" uv run -n --project $PWD mcp-graphql --api-url http://localhost:3010/graphql
+```
+
+Replace `http://localhost:3010/graphql` with the URL of your local GraphQL endpoint if it differs.
 
 ## License
 

--- a/mcp_graphql/__init__.py
+++ b/mcp_graphql/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from pathlib import Path
 from typing import Any
 
 import click
@@ -45,11 +46,17 @@ class JsonParamType(click.ParamType):
         'Custom authentication headers as JSON string (e.g. \'{"Authorization": "Bearer token", "X-API-Key": "key"}\')'  # noqa: E501
     ),
 )
+@click.option(
+    "--queries-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to a .gql file with predefined GraphQL queries (optional)",
+)
 def main(
     api_url: str,
     auth_token: str | None,
     auth_type: str,
     auth_headers: dict[str, Any] | None,
+    queries_file: Path | None,
 ) -> None:
     """MCP Graphql Server - Graphql server for MCP"""
 
@@ -62,9 +69,8 @@ def main(
     # Otherwise use auth_token and auth_type if provided
     elif auth_token:
         auth_headers_dict["Authorization"] = f"{auth_type} {auth_token}"
-    # If no auth is provided, proceed with empty headers
 
-    asyncio.run(serve(api_url, auth_headers_dict))
+    asyncio.run(serve(api_url, auth_headers_dict, queries_file=queries_file))
 
 
 if __name__ == "__main__":

--- a/mcp_graphql/types.py
+++ b/mcp_graphql/types.py
@@ -2,6 +2,7 @@ from typing import Any, TypedDict
 
 from gql.client import AsyncClientSession
 from gql.dsl import DSLSchema
+from graphql.language.ast import OperationDefinitionNode
 
 
 class ServerContext(TypedDict):
@@ -9,6 +10,11 @@ class ServerContext(TypedDict):
 
     session: AsyncClientSession
     dsl_schema: DSLSchema
+
+    # Optional mapping of query name -> GraphQL query string when the server is
+    # started with a predefined queries file.  When absent or empty, the server
+    # will fall back to exposing every query present in the remote schema.
+    predefined_queries: dict[str, OperationDefinitionNode] | None
 
 
 class SchemaRetrievalError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-graphql"
-version = "0.3.3"
+version = "0.4.0"
 description = "MCP server for GraphQL"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ cli = [
 
 [[package]]
 name = "mcp-graphql"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- Introduced a new command-line option to specify a file containing predefined GraphQL queries.
- Enhanced the server lifecycle management to parse and load queries from the specified file.
- Updated the tool execution logic to allow for predefined queries, improving flexibility and usability.
- Added error handling for query parsing to ensure robustness.