### PR TITLE
Possibility to get modelcontextprotocol/python-sdk server as is

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ query ListPosts {
 ```python
 import asyncio
 from pathlib import Path
-from mcp_graphql import serve
+from mcp_graphql import make_server, serve
 
 auth_headers = {"Authorization": "Bearer your-token"}
 api_url = "https://api.example.com/graphql"
@@ -172,6 +172,17 @@ query Hello($name: String!) {
 
 asyncio.run(serve(api_url, auth_headers, queries=queries_str, max_depth=3))
 ```
+
+Create low level MCP server:
+
+```python
+server = make_server(api_url, auth_headers, queries=queries_str, max_depth=3)
+```
+
+For low level server with Streamable HTTP implementations, see:
+
+- [Stateful server](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-streamablehttp)
+- [Stateless server](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-streamablehttp-stateless)
 
 ## Configuration
 

--- a/mcp_graphql/server.py
+++ b/mcp_graphql/server.py
@@ -520,13 +520,13 @@ async def call_tool_impl(
     return [mcp_types.TextContent(type="text", text="Tool not found")]
 
 
-async def serve(
+def make_server(
     api_url: str,
     auth_headers: dict[str, str] | None,
     queries_file: Path | None = None,
     queries: str | None = None,
     max_depth: int = 5,
-) -> None:
+) -> Server:
     server = Server[ServerContext](
         "mcp-graphql",
         lifespan=partial(
@@ -569,6 +569,24 @@ async def serve(
             name=type_name,
             description=print_type(ds._schema.type_map[type_name]),
         )
+
+    return server
+
+
+async def serve(
+    api_url: str,
+    auth_headers: dict[str, str] | None,
+    queries_file: Path | None = None,
+    queries: str | None = None,
+    max_depth: int = 5,
+) -> None:
+    server = make_server(
+        api_url,
+        auth_headers,
+        queries_file=queries_file,
+        queries=queries,
+        max_depth=max_depth,
+    )
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(


### PR DESCRIPTION
I need to get the Server as it is in order to be able to run the server under http or websocket.